### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/tests/coordinate-formatting.test.ts
+++ b/tests/coordinate-formatting.test.ts
@@ -20,11 +20,14 @@ class MockElement {
 	set innerHTML(value: string) {
 		this._innerHTML = value;
 		// Convert HTML to text content (strip HTML entities and tags)
-		this._textContent = value
+		let text = value
 			.replace(/&deg;/g, '°')
 			.replace(/&nbsp;/g, ' ')
 			.replace(/&pm;/g, '±')
 			.replace(/<[^>]*>/g, '');
+		// Ensure no angle brackets remain to avoid HTML element injection in textContent
+		text = text.replace(/</g, '').replace(/>/g, '');
+		this._textContent = text;
 	}
 
 	get textContent(): string {


### PR DESCRIPTION
Potential fix for [https://github.com/phieri/sweref99-nu/security/code-scanning/2](https://github.com/phieri/sweref99-nu/security/code-scanning/2)

In general, the fix is to avoid a brittle, one‑pass multi‑character regex that attempts to “sanitize” HTML, and instead either (a) use a proper HTML/DOM parser or (b) clearly and safely reduce the input to plain text. Since this is a test helper and we should not add heavy dependencies unnecessarily, the best approach here is to explicitly parse the minimal HTML we expect: decode a few known entities, strip tags in a way that cannot re‑introduce `<`/`>`, and ensure the result contains no angle brackets at all. This removes the multi‑character sanitization flaw and the possibility of HTML element injection through `_textContent`.

Concretely, in `tests/coordinate-formatting.test.ts`, within the `MockElement` class’s `innerHTML` setter (lines 20–27), we should refactor the sanitization into a small helper: first apply the entity replacements, then remove tags, and finally remove any remaining `<` or `>` characters. We can keep using `.replace` with global single‑character patterns for `<` and `>`, which avoids the CodeQL “incomplete multi‑character sanitization” issue. We do not need new imports; the standard `String.prototype.replace` and regular expressions are sufficient. All changes will be confined to this setter and will not alter the semantics of the tests, other than making `_textContent` guaranteed to be free of HTML/angle brackets.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
