### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/tests/coordinate-formatting.test.ts
+++ b/tests/coordinate-formatting.test.ts
@@ -19,12 +19,19 @@ class MockElement {
 
 	set innerHTML(value: string) {
 		this._innerHTML = value;
-		// Convert HTML to text content (strip HTML entities and tags)
+		// Convert HTML entities first
 		let text = value
 			.replace(/&deg;/g, '°')
 			.replace(/&nbsp;/g, ' ')
-			.replace(/&pm;/g, '±')
-			.replace(/<[^>]*>/g, '');
+			.replace(/&pm;/g, '±');
+
+		// Strip tags repeatedly until stable to avoid incomplete multi-character sanitization
+		let previous: string;
+		do {
+			previous = text;
+			text = text.replace(/<[^>]*>/g, '');
+		} while (text !== previous);
+
 		// Ensure no angle brackets remain to avoid HTML element injection in textContent
 		text = text.replace(/</g, '').replace(/>/g, '');
 		this._textContent = text;


### PR DESCRIPTION
Potential fix for [https://github.com/phieri/sweref99-nu/security/code-scanning/3](https://github.com/phieri/sweref99-nu/security/code-scanning/3)

General fix: avoid relying on a single pass of multi-character regex sanitization. Either sanitize by removing dangerous single characters directly, or repeatedly apply multi-character replacement until stable.

Best fix here (minimal behavior change): in `MockElement.innerHTML` setter, keep entity decoding, then apply tag-removal in a **fixpoint loop** until no further changes occur, then keep final angle-bracket stripping as defense-in-depth. This preserves current intent (“convert HTML to text content”) while addressing incomplete sanitization.

Change region: `tests/coordinate-formatting.test.ts`, lines around 23–30 in `set innerHTML(value: string)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
